### PR TITLE
Fix modals issue on Android

### DIFF
--- a/src/components/Documents/DocumentActionsModal.tsx
+++ b/src/components/Documents/DocumentActionsModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Linking  } from 'react-native';
+import { useEffect } from 'react';
+import { Linking } from 'react-native';
 import { useBoolean } from 'react-hanger/array';
 import DocumentContext from '../../context/DocumentContext';
 import FolderContext from '../../context/FolderContext';
@@ -27,6 +28,19 @@ const DocumentActionsModal: React.FC<Props> = ({ document, close }) => {
   const { deleteItem, isDeleting } = useDeleteData(itemContext, itemEndpoint, document.id);
   const { isMovingOut, triggerMoveDocumentOutOfFolder } = useMoveDocumentOutOfFolder(document);
   const isLoading = isMovingOut || isUpdating || isDeleting;
+
+  const hasUpdating = React.useRef<boolean>(false);
+
+  useEffect(() => {
+    if (isUpdating) {
+      hasUpdating.current = true;
+    }
+  }, [isUpdating]);
+
+  if (hasUpdating.current && !isUpdating) {
+    close();
+  }
+
   const actions = {
     delete: deleteItem,
     // download: () => {
@@ -67,14 +81,7 @@ const DocumentActionsModal: React.FC<Props> = ({ document, close }) => {
     return <PickFolder document={document} onPick={pickingFolderActions.setFalse} close={close} />;
   }
 
-  return (
-    <ActionsModalContent
-      document={document}
-      close={close}
-      isLoading={isLoading}
-      actions={actions}
-    />
-  );
+  return <ActionsModalContent document={document} close={close} isLoading={isLoading} actions={actions} />;
 };
 
 export default DocumentActionsModal;

--- a/src/components/Documents/DocumentCardActions.tsx
+++ b/src/components/Documents/DocumentCardActions.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { useBoolean } from 'react-hanger/array';
-import { Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome5';
 import { colors } from '../../style';
 import { DocumentInterface } from '../../types/Documents';
-import DocumentActionsModal from './DocumentActionsModal';
+import { UseBooleanActions } from 'react-hanger/array';
 
 const styles = StyleSheet.create({
   icon: {
@@ -17,19 +16,23 @@ const styles = StyleSheet.create({
 
 interface DocumentCardActionsProps {
   document: DocumentInterface;
+  openModalActions: UseBooleanActions;
+  setCurrentDocument: (document: DocumentInterface) => void;
 }
 
-const DocumentCardActions: React.FC<DocumentCardActionsProps> = ({ document }) => {
-  const [isModalOpen, openModalACtions] = useBoolean(false);
-
-  React.useEffect(() => {}, [isModalOpen]);
+const DocumentCardActions: React.FC<DocumentCardActionsProps> = ({
+  document,
+  openModalActions,
+  setCurrentDocument,
+}) => {
+  const onPress = () => {
+    setCurrentDocument(document);
+    openModalActions.setTrue();
+  };
 
   return (
     <View style={{ position: 'relative' }}>
-      <Modal transparent visible={isModalOpen} animationType='fade'>
-        <DocumentActionsModal document={document} close={openModalACtions.setFalse}/>
-      </Modal>
-      <TouchableOpacity onPress={openModalACtions.setTrue} style={styles.icon}>
+      <TouchableOpacity onPress={onPress} style={styles.icon}>
         <Icon style={{ fontSize: 20 }} color={colors.black} name='ellipsis-v' />
       </TouchableOpacity>
     </View>

--- a/src/components/Documents/DocumentsListWrapper.tsx
+++ b/src/components/Documents/DocumentsListWrapper.tsx
@@ -9,13 +9,21 @@ import { AnyDataInterface } from '../../types/Data';
 import { DocumentInterface } from '../../types/Documents';
 import List from '../UI/List';
 import DocumentCardActions from './DocumentCardActions';
+import { UseBooleanActions, useBoolean } from 'react-hanger/array';
 
 export interface DocumentsListWrapperProps {
   folderId?: number;
 }
 
 const getDocumentName = (item: AnyDataInterface) => item.nom;
-const getRightComponent = (item: DocumentInterface) => () => <DocumentCardActions document={item} />;
+const getRightComponent =
+  (
+    item: DocumentInterface,
+    setCurrentDocument: (document: AnyDataInterface) => void,
+    openModalActions: UseBooleanActions,
+  ) =>
+  () =>
+    <DocumentCardActions document={item} setCurrentDocument={setCurrentDocument} openModalActions={openModalActions} />;
 const getEndpoint = (item?: AnyDataInterface) => (item && item.is_folder ? `folders` : `documents`);
 const getDataContext = (item?: AnyDataInterface) => (item && item.is_folder ? FolderContext : DocumentContext);
 
@@ -26,8 +34,11 @@ const DocumentsListWrapper: React.FC<DocumentsListWrapperProps> = ({ folderId })
   const documentContext = React.useContext(DocumentContext);
   const folderContext = React.useContext(FolderContext);
   const openItem = useOpenItem();
+  const [isModalOpen, openModalActions] = useBoolean(false);
+
   let isFetching = fetchFolders.isFetching || fetchDocuments.isFetching;
   const documents = findBy(documentContext.list, { folder_id: folderId });
+  const [currentDocument, setCurrentDocument] = React.useState<AnyDataInterface | null>(null);
   const folders = folderContext.list.filter(item => item.is_folder && item?.dossier_parent?.id === folderId);
   const list = [...folders, ...documents];
 
@@ -41,13 +52,16 @@ const DocumentsListWrapper: React.FC<DocumentsListWrapperProps> = ({ folderId })
 
   return (
     <List
+      currentDocument={currentDocument}
+      isModalOpen={isModalOpen}
+      openModalActions={openModalActions}
       data={list}
       onItemPress={onPress}
       isFetchingData={isFetching}
       triggerFetchData={fetchDocumentsAndFolders}
       hasThumbnail
       getName={getDocumentName}
-      getItemRightComponent={getRightComponent}
+      getItemRightComponent={(item: AnyDataInterface) => getRightComponent(item, setCurrentDocument, openModalActions)}
       getDataContext={getDataContext}
       getLeftActionEndpoint={getEndpoint}
       getRightActionEndpoint={getEndpoint}

--- a/src/components/UI/List.tsx
+++ b/src/components/UI/List.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RefreshControl } from 'react-native';
+import { Modal, RefreshControl } from 'react-native';
 import { SwipeListView } from 'react-native-swipe-list-view';
 import { colors } from '../../style';
 import { AnyDataInterface, ListContextInterface } from '../../types/Data';
@@ -7,6 +7,8 @@ import Card from './Card';
 import ListHiddenItem from './ListHiddenItem';
 import SearchBar from './SearchBar';
 import Separator from './Separator';
+import DocumentActionsModal from '../Documents/DocumentActionsModal';
+import { UseBooleanActions } from 'react-hanger/array';
 
 type DataCardInterface = { item: AnyDataInterface };
 
@@ -21,8 +23,11 @@ interface Props {
   itemIconName?: string;
   getLeftActionEndpoint: (item?: AnyDataInterface) => string;
   onItemPress: (item: AnyDataInterface) => void;
+  isModalOpen: boolean;
+  openModalActions: UseBooleanActions;
   getRightActionEndpoint: (item?: AnyDataInterface) => string;
   triggerFetchData: () => Promise<void>;
+  currentDocument?: AnyDataInterface | null;
 }
 
 const List: React.FC<Props> = ({
@@ -34,10 +39,13 @@ const List: React.FC<Props> = ({
   hasThumbnail,
   isFetchingData,
   itemIconName,
+  isModalOpen,
+  openModalActions,
   getLeftActionEndpoint,
   onItemPress,
   getRightActionEndpoint,
   triggerFetchData,
+  currentDocument,
 }) => {
   const [search, setSearch] = React.useState<string>('');
   const filteredData = data.filter((datum: AnyDataInterface) =>
@@ -46,6 +54,15 @@ const List: React.FC<Props> = ({
 
   return (
     <>
+      {currentDocument && (
+        <Modal
+          visible={isModalOpen}
+          animationType='fade'
+          transparent
+          onRequestClose={() => openModalActions.setFalse()}>
+          <DocumentActionsModal document={currentDocument} close={openModalActions.setFalse} />
+        </Modal>
+      )}
       <SearchBar onChange={setSearch} />
       <SwipeListView
         data={filteredData}


### PR DESCRIPTION
- Remove modal creation from item component -> improve performance, only one modal is instantiated with the current document data : before this fix, there were **n** modals instantiated where **n** is the number of documents in the list. 